### PR TITLE
Make it statically generate blog pages

### DIFF
--- a/components/blog/ArticleCard.tsx
+++ b/components/blog/ArticleCard.tsx
@@ -22,7 +22,7 @@ export const ArticleGrid = ({children}: any) => (
 
 const ArticleCard = ({entry, hero}: Props) => {
 
-    const articleURL = '/blog/entry/' + entry.slug
+    const articleURL = '/blog/' + entry.slug
     const splitTitle = parseWithBudouX(entry.title, entry.slug)
 
     return (

--- a/components/blog/BlogImage.tsx
+++ b/components/blog/BlogImage.tsx
@@ -60,7 +60,7 @@ const BlogImage = ({src, alt, imageData, style}: BlogImageProps) => {
     const [modalState, setModalState] = useState(false)
     return (
         <>
-            <div className={styles.blog_img_wrapper} style={style}>
+            <figure className={styles.blog_img_wrapper} style={style}>
                 <Image
                     src={srcPath}
                     alt={alt || src}
@@ -74,11 +74,11 @@ const BlogImage = ({src, alt, imageData, style}: BlogImageProps) => {
                     onClick={() => setModalState(true)}
                 />
                 {caption != '' &&
-                    <p className={styles.blog_img_caption}>
+                    <figcaption className={styles.blog_img_caption}>
                         {parseInlineMarkdown(caption)}
-                    </p>
+                    </figcaption>
                 }
-            </div>
+            </figure>
             <Modal
                 isOpen={modalState}
                 style={modalStyle}

--- a/components/blog/BlogMarkdown.tsx
+++ b/components/blog/BlogMarkdown.tsx
@@ -373,7 +373,7 @@ const BlogMarkdown = ({entry, imageSize, style, className}: Props) => {
                     {idx === 0 &&
                         <PageNavigation entry={entry} pagePosition={pagePosition - 1} doNotShowOnFirst={true}/>
                     }
-                    <div
+                    <article
                         className={styles.post}
                         style={{wordBreak: 'break-word'}}
                     >
@@ -394,7 +394,7 @@ const BlogMarkdown = ({entry, imageSize, style, className}: Props) => {
                                 </ReactMarkdown>
                             </MathJax>
                         </MathJaxContext>
-                    </div>
+                    </article>
                     {idx === markdown.length - 1 &&
                         <PageNavigation entry={entry} pagePosition={pagePosition - 1}/>
                     }

--- a/components/blog/BlogMarkdown.tsx
+++ b/components/blog/BlogMarkdown.tsx
@@ -308,22 +308,9 @@ type Props = {
     className?: string
 }
 
-const movePage = (pagePosition: number): void => {
-    if (typeof window !== 'undefined') {
-        const current = window.location.href
-        const root = current.split('?')[0]
-        window.location.href = `${root}?page=${pagePosition}`
-    }
-}
-
 const BlogMarkdown = ({entry, imageSize, style, className}: Props) => {
 
-    const { query } = useRouter()
-    const clampInt = (x: number, l: number, r: number) => isNaN(x) ? l : Math.floor(Math.max(l, Math.min(x, r)))
-    const pagePosition: number = clampInt(
-        parseInt(query.page as string ?? '1'), 1, entry.content.length
-    )
-    const markdown = entry.content[pagePosition - 1].map(e => e.trim())
+    const markdown = entry.content
 
     // eslint-disable-next-line react/display-name
     GoNextPage = ({txt}: {txt: string}) => (

--- a/components/blog/BlogMarkdown.tsx
+++ b/components/blog/BlogMarkdown.tsx
@@ -360,6 +360,7 @@ const BlogMarkdown = ({entry, imageSize, style, className}: Props) => {
 
     return (
         <>
+            <span id={'article'}/>
             {markdown.map((content, idx) => (
                 <Block key={'window-' + idx} style={style} className={className}>
                     {idx === 0 &&

--- a/components/blog/BlogMarkdown.tsx
+++ b/components/blog/BlogMarkdown.tsx
@@ -315,7 +315,7 @@ const BlogMarkdown = ({entry, imageSize, style, className}: Props) => {
     // eslint-disable-next-line react/display-name
     GoNextPage = ({txt}: {txt: string}) => (
         <PageTransferButton
-            slug={entry.slug}
+            entry={entry}
             nextPage={entry.currentPage + 1}
             buttonText={`Next: ${txt} →`}
         />

--- a/components/blog/BlogMarkdown.tsx
+++ b/components/blog/BlogMarkdown.tsx
@@ -16,7 +16,7 @@ import YouTube from "react-youtube";
 import BlogImage from "./BlogImage";
 import TwitterArchive from "./TwitterArchive";
 import {BlogImageData} from "../../lib/blog/imagePropsFetcher";
-import PageNavigation from "./PageNavigation";
+import PageNavigation, {PageTransferButton} from "./PageNavigation";
 import Block from "../Block";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faFrog, faPaperclip, faTriangleExclamation} from "@fortawesome/free-solid-svg-icons";
@@ -64,7 +64,7 @@ export const parseInlineMarkdown = (markdown: string) => {
 }
 
 // Updated when page was loaded
-let goToNextPage = () => {}
+let GoNextPage = ({txt}: {txt: string}) => <></>
 
 const myMarkdownClasses: { [content: string]: (content: string) => JSX.Element } = {
     Twitter: (content) => {
@@ -109,10 +109,8 @@ const myMarkdownClasses: { [content: string]: (content: string) => JSX.Element }
 
     'Next-page': content => {
         return (
-            <div style={{textAlign: 'center', marginBottom: '1em'}}>
-                <span onClick={goToNextPage} className={'linkButton'}>
-                    Next: {content} &rarr;
-                </span>
+            <div style={{textAlign: 'center'}}>
+                <GoNextPage txt={content}/>
             </div>
         )
     },
@@ -327,9 +325,14 @@ const BlogMarkdown = ({entry, imageSize, style, className}: Props) => {
     )
     const markdown = entry.content[pagePosition - 1].map(e => e.trim())
 
-    goToNextPage = () => {
-        movePage(pagePosition + 1)
-    }
+    // eslint-disable-next-line react/display-name
+    GoNextPage = ({txt}: {txt: string}) => (
+        <PageTransferButton
+            slug={entry.slug}
+            nextPage={entry.currentPage + 1}
+            buttonText={`Next: ${txt} →`}
+        />
+    )
 
     const markdownComponents = {
         pre: ({ children }: any) => <div className={''}>{children}</div>, // disable pre tag

--- a/components/blog/BlogMarkdown.tsx
+++ b/components/blog/BlogMarkdown.tsx
@@ -371,7 +371,7 @@ const BlogMarkdown = ({entry, imageSize, style, className}: Props) => {
             {markdown.map((content, idx) => (
                 <Block key={'window-' + idx} style={style} className={className}>
                     {idx === 0 &&
-                        <PageNavigation entry={entry} pagePosition={pagePosition - 1} doNotShowOnFirst={true}/>
+                        <PageNavigation entry={entry} doNotShowOnFirst={true}/>
                     }
                     <article
                         className={styles.post}
@@ -396,7 +396,7 @@ const BlogMarkdown = ({entry, imageSize, style, className}: Props) => {
                         </MathJaxContext>
                     </article>
                     {idx === markdown.length - 1 &&
-                        <PageNavigation entry={entry} pagePosition={pagePosition - 1}/>
+                        <PageNavigation entry={entry}/>
                     }
                 </Block>
             ))}

--- a/components/blog/BlogMarkdown.tsx
+++ b/components/blog/BlogMarkdown.tsx
@@ -346,6 +346,13 @@ const BlogMarkdown = ({entry, imageSize, style, className}: Props) => {
                     {props.children}
                 </h2>
             )
+        },
+        a: (props: any) => {
+            return (
+                <a href={props.href} target="_blank" rel="noreferrer">
+                    {props.children}
+                </a>
+            )
         }
     };
 

--- a/components/blog/BlogMarkdown.tsx
+++ b/components/blog/BlogMarkdown.tsx
@@ -314,11 +314,13 @@ const BlogMarkdown = ({entry, imageSize, style, className}: Props) => {
 
     // eslint-disable-next-line react/display-name
     GoNextPage = ({txt}: {txt: string}) => (
-        <PageTransferButton
-            entry={entry}
-            nextPage={entry.currentPage + 1}
-            buttonText={`Next: ${txt} →`}
-        />
+        <div style={{margin: '1em 0'}}>
+            <PageTransferButton
+                entry={entry}
+                nextPage={entry.currentPage + 1}
+                buttonText={`Next: ${txt} →`}
+            />
+        </div>
     )
 
     const markdownComponents = {

--- a/components/blog/PageNavigation.tsx
+++ b/components/blog/PageNavigation.tsx
@@ -9,15 +9,15 @@ type Props = {
 }
 
 type PageTransferProps = {
-    slug: string
+    entry: BlogPost
     nextPage: number
     buttonText: string
 }
 
 export const PageTransferButton = (props: PageTransferProps) => {
-    const {slug, nextPage, buttonText} = props
-    return (
-        <a href={`/blog/${slug}/${nextPage}`} className={'linkButton'}>{buttonText}</a>
+    const {entry, nextPage, buttonText} = props
+    return entry.isAll ? <></> : (
+        <a href={`/blog/${entry.slug}/${nextPage}`} className={'linkButton'}>{buttonText}</a>
     )
 }
 
@@ -37,7 +37,7 @@ const PageNavigation = ({entry, doNotShowOnFirst = false}: Props) => {
         <div style={{textAlign: 'center'}} className={'link-area'}>
             {entry.currentPage > 1 &&
                 <PageTransferButton
-                    slug={entry.slug}
+                    entry={entry}
                     nextPage={pagePosition1Indexed - 1}
                     buttonText={'← Prev'}
                 />
@@ -45,7 +45,7 @@ const PageNavigation = ({entry, doNotShowOnFirst = false}: Props) => {
             {Array.from(Array(entry.numberOfPages), (v, k) => (
                 entry.currentPage !== k + 1
                     ? <PageTransferButton
-                        slug={entry.slug}
+                        entry={entry}
                         nextPage={k + 1}
                         buttonText={k + 1 + ''}
                         key={k}
@@ -54,7 +54,7 @@ const PageNavigation = ({entry, doNotShowOnFirst = false}: Props) => {
             ))}
             {entry.currentPage < entry.numberOfPages &&
                 <PageTransferButton
-                    slug={entry.slug}
+                    entry={entry}
                     nextPage={pagePosition1Indexed + 1}
                     buttonText={'Next →'}
                 />

--- a/components/blog/PageNavigation.tsx
+++ b/components/blog/PageNavigation.tsx
@@ -1,51 +1,46 @@
-import React from "react";
+import React, {CSSProperties} from "react";
 import {BlogPost} from "../../lib/blog/load";
 import Link from "next/link";
 import {useRouter} from "next/router";
 
 type Props = {
     entry: BlogPost,
-    pagePosition: number,
     doNotShowOnFirst?: boolean
 }
 
-const PageNavigation = ({entry, pagePosition, doNotShowOnFirst = false}: Props) => {
-    const pagePosition1Indexed = pagePosition + 1;
-    const router = useRouter()
-    const urlWithoutPage = router.asPath.split('?')[0]
+const PageNavigation = ({entry, doNotShowOnFirst = false}: Props) => {
+    const pagePosition1Indexed = entry.currentPage
 
-    return entry.content.length < 2 || (doNotShowOnFirst && pagePosition < 1) ? (
+    const PageButton = ({nxt, txt}: {nxt: number, txt?: string}) => (
+        <Link href={{
+            pathname: `/blog/${entry.slug}/${nxt}`
+        }}>
+            <a>{txt ?? nxt + ""}</a>
+        </Link>
+    )
+
+    const disabledButtonStyle: CSSProperties = {
+        background: 'darkgray',
+        transform: 'translateY(2px)',
+        boxShadow: 'none',
+        cursor: 'default'
+    }
+
+    return entry.numberOfPages === 1 || (doNotShowOnFirst && entry.currentPage <= 1) ? (
         <></>
     ) : (
         <div style={{textAlign: 'center'}}>
             <div className={'link-area'}>
-                {pagePosition > 0 &&
-                    <Link href={`${urlWithoutPage}?page=${pagePosition1Indexed - 1}`}>
-                        <a>&larr; Prev</a>
-                    </Link>
+                {entry.currentPage > 1 &&
+                    <PageButton nxt={pagePosition1Indexed - 1} txt={'← Prev'}/>
                 }
-                {Array.from(Array(entry.content.length), (v, k) => (
-                    <span key={k}>
-                        {pagePosition == k ? (
-                            <a style={{
-                                background: 'darkgray',
-                                transform: 'translateY(2px)',
-                                boxShadow: 'none',
-                                cursor: 'default'
-                            }}>
-                                {k + 1}
-                            </a>
-                        ) : (
-                            <Link href={`${urlWithoutPage}?page=${k + 1}`}>
-                                <a>{k + 1}</a>
-                            </Link>
-                        )}
-                    </span>
+                {Array.from(Array(entry.numberOfPages), (v, k) => (
+                    entry.currentPage !== k + 1
+                       ? <PageButton nxt={k + 1} key={k}/>
+                       : <a style={disabledButtonStyle} key={k}>{k + 1}</a>
                 ))}
-                {pagePosition < entry.content.length - 1 &&
-                    <Link href={`${urlWithoutPage}?page=${pagePosition1Indexed + 1}`}>
-                        <a>Next &rarr;</a>
-                    </Link>
+                {entry.currentPage < entry.numberOfPages &&
+                    <PageButton nxt={pagePosition1Indexed + 1} txt={'Next →'}/>
                 }
             </div>
         </div>

--- a/components/blog/PageNavigation.tsx
+++ b/components/blog/PageNavigation.tsx
@@ -17,9 +17,7 @@ type PageTransferProps = {
 export const PageTransferButton = (props: PageTransferProps) => {
     const {slug, nextPage, buttonText} = props
     return (
-        <Link href={`/blog/${slug}/${nextPage}`}>
-            <a className={'linkButton'}>{buttonText}</a>
-        </Link>
+        <a href={`/blog/${slug}/${nextPage}`} className={'linkButton'}>{buttonText}</a>
     )
 }
 

--- a/components/blog/PageNavigation.tsx
+++ b/components/blog/PageNavigation.tsx
@@ -16,8 +16,15 @@ type PageTransferProps = {
 
 export const PageTransferButton = (props: PageTransferProps) => {
     const {entry, nextPage, buttonText} = props
+
+    const href = entry.previewContentId ?
+        `/blog/preview/${entry.previewContentId}/${nextPage}` :
+        `/blog/${entry.slug}/${nextPage}`
+
     return entry.isAll ? <></> : (
-        <a href={`/blog/${entry.slug}/${nextPage}`} className={'linkButton'}>{buttonText}</a>
+        <a href={href} className={'linkButton'}>
+            {buttonText}
+        </a>
     )
 }
 

--- a/components/blog/PageNavigation.tsx
+++ b/components/blog/PageNavigation.tsx
@@ -17,9 +17,13 @@ type PageTransferProps = {
 export const PageTransferButton = (props: PageTransferProps) => {
     const {entry, nextPage, buttonText} = props
 
-    const href = entry.previewContentId ?
+    let href = entry.previewContentId ?
         `/blog/preview/${entry.previewContentId}/${nextPage}` :
         `/blog/${entry.slug}/${nextPage}`
+
+    if (process.env.NODE_ENV === 'production') {
+        href += '#article'
+    }
 
     return entry.isAll ? <></> : (
         <a href={href} className={'linkButton'}>

--- a/components/blog/PageNavigation.tsx
+++ b/components/blog/PageNavigation.tsx
@@ -8,16 +8,23 @@ type Props = {
     doNotShowOnFirst?: boolean
 }
 
-const PageNavigation = ({entry, doNotShowOnFirst = false}: Props) => {
-    const pagePosition1Indexed = entry.currentPage
+type PageTransferProps = {
+    slug: string
+    nextPage: number
+    buttonText: string
+}
 
-    const PageButton = ({nxt, txt}: {nxt: number, txt?: string}) => (
-        <Link href={{
-            pathname: `/blog/${entry.slug}/${nxt}`
-        }}>
-            <a>{txt ?? nxt + ""}</a>
+export const PageTransferButton = (props: PageTransferProps) => {
+    const {slug, nextPage, buttonText} = props
+    return (
+        <Link href={`/blog/${slug}/${nextPage}`}>
+            <a className={'linkButton'}>{buttonText}</a>
         </Link>
     )
+}
+
+const PageNavigation = ({entry, doNotShowOnFirst = false}: Props) => {
+    const pagePosition1Indexed = entry.currentPage
 
     const disabledButtonStyle: CSSProperties = {
         background: 'darkgray',
@@ -29,20 +36,31 @@ const PageNavigation = ({entry, doNotShowOnFirst = false}: Props) => {
     return entry.numberOfPages === 1 || (doNotShowOnFirst && entry.currentPage <= 1) ? (
         <></>
     ) : (
-        <div style={{textAlign: 'center'}}>
-            <div className={'link-area'}>
-                {entry.currentPage > 1 &&
-                    <PageButton nxt={pagePosition1Indexed - 1} txt={'← Prev'}/>
-                }
-                {Array.from(Array(entry.numberOfPages), (v, k) => (
-                    entry.currentPage !== k + 1
-                       ? <PageButton nxt={k + 1} key={k}/>
-                       : <a style={disabledButtonStyle} key={k}>{k + 1}</a>
-                ))}
-                {entry.currentPage < entry.numberOfPages &&
-                    <PageButton nxt={pagePosition1Indexed + 1} txt={'Next →'}/>
-                }
-            </div>
+        <div style={{textAlign: 'center'}} className={'link-area'}>
+            {entry.currentPage > 1 &&
+                <PageTransferButton
+                    slug={entry.slug}
+                    nextPage={pagePosition1Indexed - 1}
+                    buttonText={'← Prev'}
+                />
+            }
+            {Array.from(Array(entry.numberOfPages), (v, k) => (
+                entry.currentPage !== k + 1
+                    ? <PageTransferButton
+                        slug={entry.slug}
+                        nextPage={k + 1}
+                        buttonText={k + 1 + ''}
+                        key={k}
+                    />
+                    : <a style={disabledButtonStyle} className={'linkButton'} key={k}>{k + 1}</a>
+            ))}
+            {entry.currentPage < entry.numberOfPages &&
+                <PageTransferButton
+                    slug={entry.slug}
+                    nextPage={pagePosition1Indexed + 1}
+                    buttonText={'Next →'}
+                />
+            }
         </div>
     )
 }

--- a/components/header/NormalTitle.tsx
+++ b/components/header/NormalTitle.tsx
@@ -22,7 +22,7 @@ const extractTitle = (router: NextRouter) => {
     let subTitle = '';
 
     // Get article title
-    if (router.pathname.startsWith('/blog/entry/')) {
+    if (router.pathname.startsWith('/blog/')) {
         subTitle = pageTitle
         pageTitle = 'つまみログ';
     }

--- a/lib/blog/imagePropsFetcher.ts
+++ b/lib/blog/imagePropsFetcher.ts
@@ -5,7 +5,7 @@ export type BlogImageData = { size: {width: number, height: number}, caption: st
 
 export const fetchAllImageProps = async (entry: BlogPost, useCloudinaryApi = true) => {
 
-    const markdown = entry.content.join()
+    const markdown = entry.content.join('\n')
     const slug = entry.slug.replace('_', '')
 
     const dict = {} as { [path: string]: BlogImageData }

--- a/lib/blog/imagePropsFetcher.ts
+++ b/lib/blog/imagePropsFetcher.ts
@@ -3,31 +3,50 @@ import {BlogPost} from "./load";
 
 export type BlogImageData = { size: {width: number, height: number}, caption: string }
 
+const fetchFromCloudinary = async (slug: string) => {
+    let dict = {} as { [path: string]: BlogImageData }
+
+    const cloudinary = require('../cloudinary')
+    const searchResult = await cloudinary.search
+        .expression(`resource_type:image AND folder=blog/${slug}`)
+        .max_results(500)
+        .execute()
+
+    searchResult.resources.forEach((image: any) => {
+        const src = '/' + image.public_id
+        dict[src] = {
+            size: {
+                width: parseInt(image.width ?? '800', 10),
+                height: parseInt(image.height ?? '600', 10),
+            },
+            caption: ''
+        }
+    })
+
+    return dict
+}
+
 export const fetchAllImageProps = async (entry: BlogPost, useCloudinaryApi = true) => {
 
     const markdown = entry.content.join('\n')
     const slug = entry.slug.replace('_', '')
 
-    const dict = {} as { [path: string]: BlogImageData }
+    let dict = {} as { [path: string]: BlogImageData }
+
+    type CloudinaryCache = { [slug: string]: { [path: string]: BlogImageData } }
+    if (!process.env.CLOUDINARY_CACHE) {
+        const cache: CloudinaryCache = {}
+        process.env.CLOUDINARY_CACHE = JSON.stringify(cache)
+    }
 
     if (useCloudinaryApi) {
-        const cloudinary = require('../cloudinary')
-        await cloudinary.search
-            .expression(`resource_type:image AND folder=blog/${slug}`)
-            .max_results(500)
-            .execute()
-            .then((result: any) => {
-                result.resources.forEach((image: any) => {
-                    const src = '/' + image.public_id
-                    dict[src] = {
-                        size: {
-                            width: parseInt(image.width ?? '800', 10),
-                            height: parseInt(image.height ?? '600', 10),
-                        },
-                        caption: ''
-                    }
-                })
-            });
+        let cache = JSON.parse(process.env.CLOUDINARY_CACHE) as CloudinaryCache
+        dict = cache[slug]
+        if (!dict) {
+            dict = await fetchFromCloudinary(slug)
+            cache[slug] = dict
+        }
+        process.env.CLOUDINARY_CACHE = JSON.stringify(cache)
     }
 
     const srcRegex = new RegExp('^!\\[.*?\]\\(')

--- a/lib/blog/load.ts
+++ b/lib/blog/load.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import matter from "gray-matter";
 import {getReadTimeSecond} from "./readTime";
 import parse from "./parse";
-import {createErrorArticle} from "../../pages/blog/preview/[id]";
+import {createErrorArticle} from "../../pages/blog/preview/[...id]";
 import microCMS from "../microCMS";
 
 export type BlogPost = {

--- a/lib/blog/load.ts
+++ b/lib/blog/load.ts
@@ -68,7 +68,12 @@ const buildBlogPost = async (
     const parsedContent: string[][] = await parse(matterResult.content)
     let content: string[] = []
     if (option?.all) {
-        content = parsedContent.flat()
+        content = parsedContent
+            .map((windows, idx) => {
+                windows[0] = `<span id="original-page-${idx + 1}"></span>` + windows[0]
+                return windows
+            })
+            .flat()
     } else if (pagePosition)  {
         if (pagePosition > parsedContent.length) {
             throw 'Too large page position!'

--- a/lib/blog/load.ts
+++ b/lib/blog/load.ts
@@ -150,6 +150,22 @@ export const getAllPostSlugs = async (): Promise<string[]> => {
     return fileNames.map(e => e.slice(0, e.lastIndexOf('.')))
 }
 
+export const getAllPostPaths = async () => {
+    const slugs = await getAllPostSlugs()
+    let paths = []
+
+    for (const slug of slugs) {
+        const entry = await getPostData(slug)
+        for (let i = 1; i <= entry.numberOfPages; i++) {
+            paths.push({ params: { slug: [slug, i + ""] } })
+        }
+        paths.push({ params: { slug: [slug] } })
+        paths.push({ params: { slug: [slug, 'all'] } })
+    }
+
+    return paths
+}
+
 export const getAllTags = async() => {
     const fileNames = await fetchAllMarkdownFileNames()
     const nested = fileNames

--- a/lib/blog/load.ts
+++ b/lib/blog/load.ts
@@ -77,7 +77,7 @@ export const getPostData = async (slug: string, option?: {pagePos1Indexed?: numb
     } as BlogPost
 }
 
-export const getPreviewPostData = async (contentId: string) => {
+export const getPreviewPostData = async (contentId: string, option?: {pagePos1Indexed?: number, all?: boolean}) => {
     const data = await microCMS.get({
         endpoint: "blog-preview",
         contentId
@@ -88,7 +88,15 @@ export const getPreviewPostData = async (contentId: string) => {
     }
 
     const matterResult = matter(data.md)
-    const content = await parse(matterResult.content)
+    const pagePosition = option?.pagePos1Indexed
+
+    const parsedContent: string[][] = await parse(matterResult.content)
+    let content: string[] = []
+    if (option?.all) {
+        content = parsedContent.flat()
+    } else if (pagePosition)  {
+        content = parsedContent[pagePosition - 1]
+    }
 
     const tags = matterResult.data.tags
         .split(',')

--- a/lib/blog/load.ts
+++ b/lib/blog/load.ts
@@ -121,18 +121,9 @@ export const getSortedPostsData = async (tag:string = '') => {
     return JSON.parse(JSON.stringify(sorted))
 }
 
-export const getAllPostSlugs = async () => {
+export const getAllPostSlugs = async (): Promise<string[]> => {
     const fileNames = await fetchAllMarkdownFileNames()
-
-    return fileNames
-        .map(e => {
-            const tmp = e.split('.')
-            tmp.pop()
-            return tmp.join('.')
-        })
-        .map(fileName => ({
-            params: { slug: fileName }
-        }))
+    return fileNames.map(e => e.slice(0, e.lastIndexOf('.')))
 }
 
 export const getAllTags = async() => {

--- a/lib/blog/load.ts
+++ b/lib/blog/load.ts
@@ -17,6 +17,7 @@ export type BlogPost = {
     readTime: number
     numberOfPhotos?: number
     held?: string
+    isAll: boolean
     currentPage: number
     numberOfPages: number
     content: string[]
@@ -69,6 +70,7 @@ export const getPostData = async (slug: string, option?: {pagePos1Indexed?: numb
         slug,
         content,
         tags,
+        isAll: option?.all ?? false,
         numberOfPages: parsedContent.length,
         currentPage: pagePosition,
         readTime: getReadTimeSecond(matterResult.content),
@@ -107,6 +109,7 @@ export const getPreviewPostData = async (contentId: string, option?: {pagePos1In
         slug: data.slug,
         content,
         tags,
+        isAll: option?.all ?? false,
         readTime: getReadTimeSecond(content.join()),
         ...matterResult.data
     } as BlogPost

--- a/lib/blog/load.ts
+++ b/lib/blog/load.ts
@@ -29,6 +29,13 @@ const getFileContents = (slug: string) => {
             : fs.readFileSync(fullPath + 'x', 'utf8')
 }
 
+const fetchAllMarkdownFileNames = async () => (
+    (await fs.promises.readdir(postsDirectory)).filter(e => {
+        const ext = e.split('.').slice(-1)[0]
+        return ext === 'md' || ext === 'mdx'
+    })
+)
+
 export const getPostData = async (slug: string) => {
     const fileContents = getFileContents(slug)
     const matterResult = matter(fileContents)
@@ -82,7 +89,7 @@ export const getPreviewPostData = async (contentId: string) => {
 }
 
 export const getSortedPostsData = async (tag:string = '') => {
-    const fileNames = fs.readdirSync(postsDirectory)
+    const fileNames = await fetchAllMarkdownFileNames()
     const allPostsData = fileNames
         .map(fileName => {
             const slug = fileName
@@ -115,21 +122,21 @@ export const getSortedPostsData = async (tag:string = '') => {
 }
 
 export const getAllPostSlugs = async () => {
-    const fileNames = fs.readdirSync(postsDirectory)
+    const fileNames = await fetchAllMarkdownFileNames()
 
-    return fileNames.map(fileName => {
-        return {
-            params: {
-                slug: fileName
-                    .replace(/\.mdx$/, '')
-                    .replace(/\.md$/, '')
-            }
-        }
-    })
+    return fileNames
+        .map(e => {
+            const tmp = e.split('.')
+            tmp.pop()
+            return tmp.join('.')
+        })
+        .map(fileName => ({
+            params: { slug: fileName }
+        }))
 }
 
 export const getAllTags = async() => {
-    const fileNames = fs.readdirSync(postsDirectory)
+    const fileNames = await fetchAllMarkdownFileNames()
     const nested = fileNames
         .map(fileName => fileName
             .replace(/\.mdx$/, '')

--- a/lib/whats_new.ts
+++ b/lib/whats_new.ts
@@ -19,7 +19,7 @@ export const getWhatsNewRecords: () => Promise<WhatsNewRecord[]> = async () => {
     for (const post of blogData) {
         records.push({
             type: 'blog',
-            text: `記事「[${post.title}](https://trpfrog.net/blog/entry/${post.slug})」を公開しました！`,
+            text: `記事「[${post.title}](https://trpfrog.net/blog/${post.slug})」を公開しました！`,
             date: dayjs(post.date).format('YYYY-MM-DD')
         })
     }

--- a/next.config.js
+++ b/next.config.js
@@ -32,7 +32,12 @@ module.exports = {
                 source: '/notes/:path*',
                 destination: '/blog/:path*',
                 permanent: true
-            }
+            },
+            {
+                source: '/blog/entry/:slug',
+                destination: '/blog/:slug',
+                permanent: true
+            },
         ]
     }
 }

--- a/next.config.js
+++ b/next.config.js
@@ -30,7 +30,7 @@ module.exports = {
             },
             {
                 source: '/notes/:path*',
-                destination: '/blog/entry/:path*',
+                destination: '/blog/:path*',
                 permanent: true
             }
         ]

--- a/pages/api/posts/[...slug].ts
+++ b/pages/api/posts/[...slug].ts
@@ -3,12 +3,15 @@ import {getPostData} from "../../../lib/blog/load";
 import {fetchAllImageProps} from "../../../lib/blog/imagePropsFetcher";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
-    const slug = req.query.slug as string
+    const [slug, page] = req.query.slug as string[]
 
     res.setHeader('Content-Type', 'application/json')
     if (slug) {
         res.statusCode = 200
-        const entry = await getPostData(slug)
+        const entry = await getPostData(slug, {
+            pagePos1Indexed: parseInt(page, 10) || -1,
+            all: page === 'all'
+        })
         const imageSize = await fetchAllImageProps(entry, false);
         res.end(JSON.stringify({...entry, imageSize}))
     } else {

--- a/pages/blog/[...slug].tsx
+++ b/pages/blog/[...slug].tsx
@@ -47,15 +47,6 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async ({params}
         return { notFound: true }
     }
 
-    if (page === 'all' && entry.numberOfPages === 1) {
-        return {
-            redirect: {
-                permanent: true,
-                destination: `/blog/${entry.slug}`
-            }
-        }
-    }
-
     const imageSize = await fetchAllImageProps(entry);
     return {
         props: {

--- a/pages/blog/[...slug].tsx
+++ b/pages/blog/[...slug].tsx
@@ -94,7 +94,7 @@ const Article: NextPage<PageProps> = ({ entry, imageSize }) => {
         // eslint-disable-next-line react-hooks/rules-of-hooks
         useEffect(() => {
             const f = async () => {
-                return await fetch(`/api/posts/${post.slug}`).then((res) =>
+                return await fetch(`/api/posts/${post.slug}/${post.currentPage}`).then((res) =>
                     res.json()
                 )
             }

--- a/pages/blog/[...slug].tsx
+++ b/pages/blog/[...slug].tsx
@@ -7,7 +7,7 @@ import Layout from "../../components/Layout";
 import Title from "../../components/Title";
 import Block from "../../components/Block";
 
-import {BlogPost, getAllPostSlugs, getPostData} from "../../lib/blog/load";
+import {BlogPost, getAllPostPaths, getPostData} from "../../lib/blog/load";
 import {BlogImageData, fetchAllImageProps} from "../../lib/blog/imagePropsFetcher";
 
 import BlogMarkdown, {getPureCloudinaryPath} from "../../components/blog/BlogMarkdown";
@@ -40,12 +40,7 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async ({params}
         all: page === 'all'
     }
 
-    let entry: BlogPost
-    try {
-        entry = await getPostData(slug, postDataOption)
-    } catch (e) {
-        return { notFound: true }
-    }
+    const entry: BlogPost = await getPostData(slug, postDataOption)
 
     const imageSize = await fetchAllImageProps(entry);
     return {
@@ -57,20 +52,8 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async ({params}
 }
 
 export const getStaticPaths: GetStaticPaths<Params> = async () => {
-    let paths = []
-    const slugs = await getAllPostSlugs()
-
-    for (const slug of slugs) {
-        const MAX_PAGE_NUMBERS = 10
-        for (let i = 1; i <= MAX_PAGE_NUMBERS; i++) {
-            paths.push({ params: { slug: [slug, i + ""] } })
-        }
-        paths.push({ params: { slug: [slug] } })
-        paths.push({ params: { slug: [slug, 'all'] } })
-    }
-
     return {
-        paths,
+        paths: await getAllPostPaths(),
         fallback: false
     }
 }

--- a/pages/blog/[...slug].tsx
+++ b/pages/blog/[...slug].tsx
@@ -16,12 +16,11 @@ import styles from '../../styles/blog/blog.module.scss';
 
 import {NextSeo} from "next-seo";
 import {doMarkdownHMR} from "../../lib/blog/fileWatch";
-import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faFlask} from "@fortawesome/free-solid-svg-icons";
 import Tag from "../../components/blog/Tag";
 import {parseWithBudouX} from "../../lib/wordSplit";
 import {parseCookies, setCookie} from "nookies";
 import PostAttributes from "../../components/blog/PostAttributes";
+import {useRouter} from "next/router";
 
 type PageProps = {
     entry: BlogPost
@@ -115,6 +114,8 @@ const Article: NextPage<PageProps> = ({ entry, imageSize }) => {
         setUseUDFont(!useUDFont)
     }
 
+    const router = useRouter()
+
     return (
         <Layout>
             <Title style={{padding: 0, border: '5px solid var(--window-bkg-color)'}}>
@@ -164,13 +165,21 @@ const Article: NextPage<PageProps> = ({ entry, imageSize }) => {
                                 <a>訂正リクエスト</a>
                             </Link>
                             <a onClick={handleUDFontButton}>
-                                {useUDFont ? '通常フォントに戻す' : (
-                                    <>
-                                        <FontAwesomeIcon icon={faFlask}/>
-                                        <span style={{width: 5}}/>
-                                        UDフォントで見てみる
-                                    </>
-                                )}
+                                {useUDFont ? '通常フォントで読む' : 'UDフォントで読む'}
+                            </a>
+                            <a href={`/blog/${post.slug}${
+                                post.isAll
+                                    // If URL has a prv query, go back to the previous page
+                                    ? (router.query?.prv ? `/${router.query!.prv}` : '')
+                                    // To make it easier to undo a wrong operation, it adds prv query
+                                    : `/all?prv=${post.currentPage}#original-page-${post.currentPage}`
+                            }`}>
+                                {post.isAll
+                                    ? (router.query?.prv
+                                        ? `${router.query!.prv}ページに戻る`
+                                        : '複数のページに分けて読む'
+                                    )
+                                    : '全文を1ページに表示'}
                             </a>
                         </p>
                     </p>

--- a/pages/blog/[...slug].tsx
+++ b/pages/blog/[...slug].tsx
@@ -77,7 +77,7 @@ export const getStaticPaths: GetStaticPaths<Params> = async () => {
 
 const share = (slug: string) => {
     if(typeof window === 'undefined') return;
-    const articleURL = 'https://trpfrog.net/blog/entry/' + slug
+    const articleURL = 'https://trpfrog.net/blog/' + slug
     const tweetURL =  'https://twitter.com/intent/tweet?'
                 + "text=" + encodeURIComponent(document.title) + "&"
                 + "url=" + encodeURIComponent(articleURL);

--- a/pages/blog/[...slug].tsx
+++ b/pages/blog/[...slug].tsx
@@ -47,6 +47,15 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async ({params}
         return { notFound: true }
     }
 
+    if (page === 'all' && entry.numberOfPages === 1) {
+        return {
+            redirect: {
+                permanent: true,
+                destination: `/blog/${entry.slug}`
+            }
+        }
+    }
+
     const imageSize = await fetchAllImageProps(entry);
     return {
         props: {

--- a/pages/blog/[...slug].tsx
+++ b/pages/blog/[...slug].tsx
@@ -70,7 +70,7 @@ export const getStaticPaths: GetStaticPaths<Params> = async () => {
     const slugs = await getAllPostSlugs()
 
     for (const slug of slugs) {
-        const MAX_PAGE_NUMBERS = 15
+        const MAX_PAGE_NUMBERS = 10
         for (let i = 1; i <= MAX_PAGE_NUMBERS; i++) {
             paths.push({ params: { slug: [slug, i + ""] } })
         }

--- a/pages/blog/preview/[...id].tsx
+++ b/pages/blog/preview/[...id].tsx
@@ -37,6 +37,7 @@ const errorArticle = {
     date: '2000-10-17',
     updated: '2020-10-17',
     tags: 'test',
+    isAll: false,
     readTime: 100,
     currentPage: 1,
     numberOfPages: 1,

--- a/pages/blog/preview/[...id].tsx
+++ b/pages/blog/preview/[...id].tsx
@@ -38,7 +38,9 @@ const errorArticle = {
     updated: '2020-10-17',
     tags: 'test',
     readTime: 100,
-    content: [['Error has occurred']]
+    currentPage: 1,
+    numberOfPages: 1,
+    content: ['Error has occurred']
 } as ErrorablePost
 
 export const createErrorArticle = (errTitle: string): ErrorablePost => {
@@ -48,8 +50,16 @@ export const createErrorArticle = (errTitle: string): ErrorablePost => {
 }
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-    const entry = context.params?.id
-        ? await getPreviewPostData(context.params.id as string) as ErrorablePost
+    let [id, page] = context.params?.id as string[]
+    page = page ?? '1'
+
+    const option = {
+        pagePos1Indexed: parseInt(page),
+        all: page === 'all'
+    }
+
+    const entry = id
+        ? await getPreviewPostData(id, option) as ErrorablePost
         : createErrorArticle('ID is missing!')
     const imageSize = entry.isError ? {} : await fetchAllImageProps(entry);
     return {
@@ -67,12 +77,6 @@ const Article: NextPage<PageProps> = ({ entry: post, imageSize }) => {
             {url: post.thumbnail}
         ]
     } : {}
-
-    const { query } = useRouter()
-
-    if(query.page === 'all') {
-        post.content = [post.content.flat()]
-    }
 
     const {
         minutes: readMin,


### PR DESCRIPTION
## UI/UX 面での更新内容

- 記事を囲むタグに article を使用
- 画像とそのキャプションを囲むタグに figure, figcaption を使用
- ブログのパスを変更
  - `/blog/entry/[slug]?page=[num]` から `/blog/[slug]/[num]`
  - 旧リンクは新リンクにリダイレクトするようにした
- 次のページへボタンに a タグを使用
- 全ページ一覧表示機能を正式にサポート
  - 実は前からできた (`?page=all`)
  - メンテはしてなかった
- ページ移動ボタンの遷移先に `#article` を追加
  - 記事タイトルが大きくなったことに合わせた変更
  - これがあるとわざわざスクロールする手間が省ける
- 記事中の a タグから別サイトに飛ぶときに新規タブで飛ぶように変更