### PR TITLE
Refactor HoverScrollBox

### DIFF
--- a/src/components/atoms/HoverScrollBox/index.module.scss
+++ b/src/components/atoms/HoverScrollBox/index.module.scss
@@ -76,8 +76,20 @@
 
 .scroll_up {
   top: 10px;
+
+  opacity: 0.5;
+  &[data-scroll-position='top'] {
+    opacity: 0;
+    pointer-events: none;
+  }
 }
 
 .scroll_down {
   bottom: 10px;
+
+  opacity: 0.5;
+  &[data-scroll-position='bottom'] {
+    opacity: 0;
+    pointer-events: none;
+  }
 }

--- a/src/components/atoms/HoverScrollBox/index.tsx
+++ b/src/components/atoms/HoverScrollBox/index.tsx
@@ -3,95 +3,49 @@
 import React from 'react'
 
 type Props = React.ComponentPropsWithoutRef<'div'>
+
 import styles from './index.module.scss'
+import { useHoverScrollBoxEvent } from './useHoverScrollBoxEvent'
+import { useScrollPosition } from './useScrollPosition'
 
 export function HoverScrollBox(props: Props) {
   const { className = '', children, ...rest } = props
 
   const scrollAreaRef = React.useRef<HTMLDivElement>(null)
-  const [intervalId, setIntervalId] = React.useState<number | null>(null)
-
-  // ボタンに hover したら自動でスクロール, (dx, dy) は単位時間あたりのスクロール量
-  const onMouseEnter = React.useCallback(
-    (dx: number, dy: number) => () => {
-      if (scrollAreaRef.current == null) return
-
-      // 自動スクロール
-      const scrollSpeed = 10
-      const newIntervalId = window.setInterval(() => {
-        scrollAreaRef.current!.scrollBy(dx * scrollSpeed, dy * scrollSpeed)
-      }, 25)
-
-      // 別の自動スクロールが動いていたらキャンセルしておく
-      if (intervalId != null) window.clearInterval(intervalId)
-      setIntervalId(newIntervalId)
-    },
-    [intervalId],
-  )
-
-  // ボタンから離れたら自動スクロールを止める
-  const onMouseLeave = React.useCallback(() => {
-    if (intervalId == null) return
-    window.clearInterval(intervalId)
-    setIntervalId(null)
-  }, [intervalId])
-
-  // スクロール位置に応じてボタンの見た目を変える
-  const scrollUpRef = React.useRef<HTMLDivElement>(null)
-  const scrollDownRef = React.useRef<HTMLDivElement>(null)
-  React.useEffect(() => {
-    const minOpacity = '0'
-    const maxOpacity = '0.5'
-
-    scrollAreaRef.current?.addEventListener('scroll', e => {
-      if (scrollUpRef.current == null || scrollDownRef.current == null) return
-
-      const { scrollTop, scrollHeight, clientHeight } =
-        e.target as HTMLDivElement
-      const scrollBottom = scrollHeight - scrollTop - clientHeight
-
-      // 最大までスクロールしたら透明にする
-      scrollUpRef.current.style.opacity =
-        scrollTop === 0 ? minOpacity : maxOpacity
-      scrollDownRef.current.style.opacity =
-        scrollBottom === 0 ? minOpacity : maxOpacity
-    })
-
-    // ボタンの見た目の初期値
-    if (scrollUpRef.current != null) {
-      scrollUpRef.current.style.opacity = minOpacity // 一番上なので透明
-    }
-    if (scrollDownRef.current != null) {
-      scrollDownRef.current.style.opacity = maxOpacity
-    }
-  }, [])
+  const { handleMouseEnter, handleMouseLeave } =
+    useHoverScrollBoxEvent(scrollAreaRef)
+  const { scrollPosition, handleScroll } = useScrollPosition()
 
   return (
     <div className={`${styles.box} ${className}`} {...rest}>
       <div
-        ref={scrollUpRef}
         className={styles.scroll_up}
-        onMouseEnter={onMouseEnter(0, -1)}
-        onTouchStart={onMouseEnter(0, -1)}
-        onMouseLeave={onMouseLeave}
-        onTouchEnd={onMouseLeave}
-        onTouchCancel={onMouseLeave}
+        onMouseEnter={handleMouseEnter(0, -1)}
+        onTouchStart={handleMouseEnter(0, -1)}
+        onMouseLeave={handleMouseLeave}
+        onTouchEnd={handleMouseLeave}
+        onTouchCancel={handleMouseLeave}
+        data-scroll-position={scrollPosition}
       >
         ▲
       </div>
       <div
-        ref={scrollDownRef}
         className={styles.scroll_down}
-        onMouseEnter={onMouseEnter(0, 1)}
-        onTouchStart={onMouseEnter(0, 1)}
-        onMouseLeave={onMouseLeave}
-        onTouchEnd={onMouseLeave}
-        onTouchCancel={onMouseLeave}
+        onMouseEnter={handleMouseEnter(0, 1)}
+        onTouchStart={handleMouseEnter(0, 1)}
+        onMouseLeave={handleMouseLeave}
+        onTouchEnd={handleMouseLeave}
+        onTouchCancel={handleMouseLeave}
+        data-scroll-position={scrollPosition}
       >
         ▼
       </div>
       <div className={styles.scroll_box_wrapper}>
-        <div className={styles.scroll_box} ref={scrollAreaRef}>
+        <div
+          className={styles.scroll_box}
+          ref={scrollAreaRef}
+          onScroll={handleScroll}
+        >
           {children}
         </div>
       </div>

--- a/src/components/atoms/HoverScrollBox/useHoverScrollBoxEvent.ts
+++ b/src/components/atoms/HoverScrollBox/useHoverScrollBoxEvent.ts
@@ -1,0 +1,36 @@
+import React from 'react'
+
+export function useHoverScrollBoxEvent(
+  scrollAreaRef: React.RefObject<HTMLElement>,
+) {
+  const [intervalId, setIntervalId] = React.useState<number | null>(null)
+
+  const handleMouseEnter = React.useCallback(
+    (dx: number, dy: number) => () => {
+      if (scrollAreaRef.current == null) return
+
+      // 自動スクロール
+      const scrollSpeed = 10
+      const newIntervalId = window.setInterval(() => {
+        scrollAreaRef.current!.scrollBy(dx * scrollSpeed, dy * scrollSpeed)
+      }, 25)
+
+      // 別の自動スクロールが動いていたらキャンセルしておく
+      if (intervalId != null) window.clearInterval(intervalId)
+      setIntervalId(newIntervalId)
+    },
+    [intervalId, scrollAreaRef],
+  )
+
+  // ボタンから離れたら自動スクロールを止める
+  const handleMouseLeave = React.useCallback(() => {
+    if (intervalId == null) return
+    window.clearInterval(intervalId)
+    setIntervalId(null)
+  }, [intervalId])
+
+  return React.useMemo(
+    () => ({ handleMouseEnter, handleMouseLeave }),
+    [handleMouseEnter, handleMouseLeave],
+  )
+}

--- a/src/components/atoms/HoverScrollBox/useScrollPosition.ts
+++ b/src/components/atoms/HoverScrollBox/useScrollPosition.ts
@@ -1,0 +1,37 @@
+import React from 'react'
+
+import { useThrottledCallback } from '@react-hookz/web'
+
+type ScrollPosition = 'top' | 'middle' | 'bottom'
+
+/**
+ * スクロール位置として `top`, `middle`, `bottom` のいずれかを返す
+ * `handleScroll` は `onScroll` に渡すこと
+ */
+export function useScrollPosition() {
+  const [scrollPosition, setScrollPosition] =
+    React.useState<ScrollPosition>('top')
+
+  const handleScroll = useThrottledCallback(
+    (e: React.UIEvent<HTMLElement>) => {
+      const { scrollTop, scrollHeight, clientHeight } =
+        e.target as HTMLDivElement
+      const scrollBottom = scrollHeight - scrollTop - clientHeight
+
+      if (scrollTop === 0) {
+        setScrollPosition('top')
+      } else if (scrollBottom === 0) {
+        setScrollPosition('bottom')
+      } else {
+        setScrollPosition('middle')
+      }
+    },
+    [],
+    100,
+  )
+
+  return React.useMemo(
+    () => ({ scrollPosition, handleScroll }),
+    [handleScroll, scrollPosition],
+  )
+}


### PR DESCRIPTION
hooks を切り出したり、最上部・最下部にいるときのスタイル変更の方法を `data-scroll-position` に state を当てるような仕組みに変更したり、より容易にメンテナンスできるようにしました。

また、最上部・最下部にいるとき三角のアイコンのあった場所がクリックできない問題を修正しました。