### PR TITLE
Remove "import React from 'react'"

### DIFF
--- a/src/app/(gallery)/_components/ImageNavigation/index.tsx
+++ b/src/app/(gallery)/_components/ImageNavigation/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import Image from 'next/legacy/image'
 import Link from 'next/link'

--- a/src/app/(gallery)/_components/ImageViewer/index.tsx
+++ b/src/app/(gallery)/_components/ImageViewer/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import Image from 'next/legacy/image'
 
 import styles from './index.module.scss'

--- a/src/app/(home)/_components/AboutMe/KCommandBox.tsx
+++ b/src/app/(home)/_components/AboutMe/KCommandBox.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import React from 'react'
+import * as React from 'react'
+import { useState } from 'react'
 
 import { faA, faB } from '@fortawesome/free-solid-svg-icons'
 import { faPlay } from '@fortawesome/free-solid-svg-icons/faPlay'
@@ -9,8 +10,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import styles from '@/app/(home)/_components/AboutMe/index.module.scss'
 
 export function KCommandBox({ children }: { children: React.ReactNode }) {
-  const [isUnlocked, setIsUnlocked] = React.useState(false)
-  const [input, setInput] = React.useState('')
+  const [isUnlocked, setIsUnlocked] = useState(false)
+  const [input, setInput] = useState('')
   const answer = '↑↑↓↓←→←→BA' // ソースまで辿り着くような人間はどうせこれも知ってるのでソース直書きで良い
 
   const figures = {

--- a/src/app/(home)/_components/AboutMe/index.tsx
+++ b/src/app/(home)/_components/AboutMe/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { faGithub, faTwitter } from '@fortawesome/free-brands-svg-icons'
 import { faAt, faEnvelope, faHeart } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'

--- a/src/app/(home)/_components/TempTwitter/index.tsx
+++ b/src/app/(home)/_components/TempTwitter/index.tsx
@@ -1,5 +1,4 @@
-import React from 'react'
-import { Suspense } from 'react'
+import { Fragment, Suspense } from 'react'
 
 import matter from 'gray-matter'
 import ReactMarkdown from 'react-markdown'
@@ -43,7 +42,7 @@ export async function TempTwitter() {
       const [date, ...contentArr] = line.split('---')
       const content = contentArr.join('---')
       return (
-        <React.Fragment key={`temp-twitter-${idx}`}>
+        <Fragment key={`temp-twitter-${idx}`}>
           <span
             className={styles.date}
             style={{
@@ -63,7 +62,7 @@ export async function TempTwitter() {
               {content}
             </ReactMarkdown>
           </div>
-        </React.Fragment>
+        </Fragment>
       )
     })
 

--- a/src/app/(home)/_components/TrpFrogAnimation/RotateButton.tsx
+++ b/src/app/(home)/_components/TrpFrogAnimation/RotateButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { memo } from 'react'
 
 import { faRotate, faStop } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -11,7 +11,7 @@ interface Props {
   onClick?: () => void
 }
 
-export const RotateButton = React.memo(function RotateButton(props: Props) {
+export const RotateButton = memo(function RotateButton(props: Props) {
   return (
     <>
       <button

--- a/src/app/(home)/_components/TrpFrogAnimation/index.tsx
+++ b/src/app/(home)/_components/TrpFrogAnimation/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import React from 'react'
+import * as React from 'react'
+import { useCallback, useRef, useState } from 'react'
 
 import { RotateButton } from '@/app/(home)/_components/TrpFrogAnimation/RotateButton'
 import { useRotateAnimation } from '@/app/(home)/_components/TrpFrogAnimation/useRotateAnimation'
@@ -16,10 +17,10 @@ type Props = {
 }
 
 export function TrpFrogAnimation({ children, id }: Props) {
-  const ref = React.useRef<HTMLDivElement>(null)
+  const ref = useRef<HTMLDivElement>(null)
   const rotateAnimation = useRotateAnimation()
 
-  const rotateCallback = React.useCallback(() => {
+  const rotateCallback = useCallback(() => {
     if (rotateAnimation.isRotated) {
       rotateAnimation.stopAnimation()
     } else {
@@ -32,7 +33,7 @@ export function TrpFrogAnimation({ children, id }: Props) {
   })
   const rpm = Math.abs(rawRpm)
 
-  const [maxRpm, setMaxRpm] = React.useState(0)
+  const [maxRpm, setMaxRpm] = useState(0)
   const showMaxRpm = maxRpm >= 150
 
   return (

--- a/src/app/(home)/_components/TrpFrogAnimation/useRotateAnimation.ts
+++ b/src/app/(home)/_components/TrpFrogAnimation/useRotateAnimation.ts
@@ -1,17 +1,17 @@
-import React from 'react'
+import { useRef, useState, useCallback } from 'react'
 
 import { AnglePickerHandle } from '@/components/atoms/AnglePicker'
 
 export function useRotateAnimation() {
   // AnglePicker の操作用 ref
-  const anglePickerRef = React.useRef<AnglePickerHandle>(null)
+  const anglePickerRef = useRef<AnglePickerHandle>(null)
 
-  const [intervalId, setIntervalId] = React.useState<number | null>(null)
-  const [rotateDirection, setRotateDirection] = React.useState<
-    'left' | 'right'
-  >('right')
+  const [intervalId, setIntervalId] = useState<number | null>(null)
+  const [rotateDirection, setRotateDirection] = useState<'left' | 'right'>(
+    'right',
+  )
 
-  const startAnimation = React.useCallback(() => {
+  const startAnimation = useCallback(() => {
     if (intervalId !== null) {
       return
     }
@@ -23,7 +23,7 @@ export function useRotateAnimation() {
     setIntervalId(id)
   }, [intervalId, rotateDirection])
 
-  const stopAnimation = React.useCallback(() => {
+  const stopAnimation = useCallback(() => {
     if (intervalId === null) {
       return
     }

--- a/src/app/(home)/_components/TrpFrogAnimation/useRpmCalculation.ts
+++ b/src/app/(home)/_components/TrpFrogAnimation/useRpmCalculation.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import { useRef, useState, useCallback } from 'react'
 
 import { Queue } from '@/lib/queue'
 
@@ -31,13 +31,13 @@ export function useRpmCalculation(
 ) {
   if (queueTTLMillis < 1) throw new Error('heapSize must be greater than 0')
 
-  const q = React.useRef<Queue<RpmRecord> | null>(null)
+  const q = useRef<Queue<RpmRecord> | null>(null)
   if (!q.current) {
     q.current = new Queue()
   }
 
-  const [diffSum, setDiffSum] = React.useState(0)
-  const pushDegree = React.useCallback(
+  const [diffSum, setDiffSum] = useState(0)
+  const pushDegree = useCallback(
     (degree: number) => {
       const curLast = q.current?.last
       if (curLast) {

--- a/src/app/(home)/_components/TrpFrogIconFrame/Description.tsx
+++ b/src/app/(home)/_components/TrpFrogIconFrame/Description.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { get } from '@vercel/edge-config'
 
 import {

--- a/src/app/(home)/_components/TrpFrogIconFrame/IconFrame.tsx
+++ b/src/app/(home)/_components/TrpFrogIconFrame/IconFrame.tsx
@@ -1,6 +1,4 @@
 'use client'
-import React from 'react'
-
 import Balancer from 'react-wrap-balancer'
 import useSWR, { Fetcher } from 'swr'
 

--- a/src/app/(home)/_components/TrpFrogIconFrame/index.tsx
+++ b/src/app/(home)/_components/TrpFrogIconFrame/index.tsx
@@ -1,4 +1,5 @@
-import React, { Suspense } from 'react'
+import { Suspense } from 'react'
+import * as React from 'react'
 
 import { WaveText } from '@/components/atoms/WaveText'
 import { Block } from '@/components/molecules/Block'

--- a/src/app/(home)/_components/WhatsNew/index.tsx
+++ b/src/app/(home)/_components/WhatsNew/index.tsx
@@ -1,8 +1,6 @@
 import fs from 'fs'
 import path from 'path'
 
-import React from 'react'
-
 import dayjs from 'dayjs'
 import ReactMarkdown from 'react-markdown'
 

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css'
 import { TrpFrogIconFrame } from '@/app/(home)/_components/TrpFrogIconFrame'
 

--- a/src/app/balloon/BalloonApp.tsx
+++ b/src/app/balloon/BalloonApp.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import { Button } from '@/components/atoms/Button'
 import { Block } from '@/components/molecules/Block'

--- a/src/app/balloon/_components/Balloon/index.tsx
+++ b/src/app/balloon/_components/Balloon/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { Dispatch, useId, useState } from 'react'
+import { Dispatch, useId, useState } from 'react'
 
 import { useReward } from 'react-rewards'
 import useSound from 'use-sound'

--- a/src/app/balloon/_components/BalloonArray/index.tsx
+++ b/src/app/balloon/_components/BalloonArray/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { useReward } from 'react-rewards'
 

--- a/src/app/blog/[slug]/[[...options]]/_components/ArticleSidebar.tsx
+++ b/src/app/blog/[slug]/[[...options]]/_components/ArticleSidebar.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Block } from '@/components/molecules/Block'
 import { HeaderFollowSticky } from '@/components/organisms/Header'
 

--- a/src/app/blog/[slug]/[[...options]]/_components/EditButton.tsx
+++ b/src/app/blog/[slug]/[[...options]]/_components/EditButton.tsx
@@ -1,7 +1,4 @@
 'use client'
-
-import React from 'react'
-
 import { Button } from '@/components/atoms/Button'
 
 import { openInCotEditor } from '@blog/actions/openInCotEditor'

--- a/src/app/blog/[slug]/[[...options]]/_components/EntryButtons.tsx
+++ b/src/app/blog/[slug]/[[...options]]/_components/EntryButtons.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { faTwitter } from '@fortawesome/free-brands-svg-icons'
 import { faArrowLeft, faPencil } from '@fortawesome/free-solid-svg-icons'

--- a/src/app/blog/[slug]/[[...options]]/_components/ShareSpan.tsx
+++ b/src/app/blog/[slug]/[[...options]]/_components/ShareSpan.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React from 'react'
+import * as React from 'react'
 
 const share = (slug: string) => {
   if (typeof window === 'undefined') return

--- a/src/app/blog/[slug]/[[...options]]/page.tsx
+++ b/src/app/blog/[slug]/[[...options]]/page.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Metadata } from 'next'
 
 import { MainWrapper } from '@/components/atoms/MainWrapper'

--- a/src/app/blog/[slug]/layout.tsx
+++ b/src/app/blog/[slug]/layout.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { retrieveAllPostSlugs } from '@blog/_lib/load'
 

--- a/src/app/blog/[slug]/og-image/components.tsx
+++ b/src/app/blog/[slug]/og-image/components.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { ogFonts, ogpImageSize } from '@blog/[slug]/og-image/variables'
 

--- a/src/app/blog/[slug]/og-image/route.tsx
+++ b/src/app/blog/[slug]/og-image/route.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { ImageResponse } from 'next/og'
 import { ImageResponseOptions, NextRequest } from 'next/server'
 

--- a/src/app/blog/_components/ArticleCard/ArticleCardGrid/index.tsx
+++ b/src/app/blog/_components/ArticleCard/ArticleCardGrid/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import styles from './index.module.scss'
 

--- a/src/app/blog/_components/ArticleCard/ArticleTitle/index.tsx
+++ b/src/app/blog/_components/ArticleCard/ArticleTitle/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import Balancer from 'react-wrap-balancer'
 

--- a/src/app/blog/_components/ArticleCard/Card/index.tsx
+++ b/src/app/blog/_components/ArticleCard/Card/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import styles from './index.module.scss'
 

--- a/src/app/blog/_components/ArticleCard/TagBar/index.tsx
+++ b/src/app/blog/_components/ArticleCard/TagBar/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { Tag } from '@blog/_components/Tag'
 

--- a/src/app/blog/_components/ArticleCard/index.tsx
+++ b/src/app/blog/_components/ArticleCard/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { faCalendarDay, faClock } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'

--- a/src/app/blog/_components/ArticleGrid/index.tsx
+++ b/src/app/blog/_components/ArticleGrid/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import styles from './index.module.scss'
 

--- a/src/app/blog/_components/ArticleHeader/index.tsx
+++ b/src/app/blog/_components/ArticleHeader/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import Balancer from 'react-wrap-balancer'
 

--- a/src/app/blog/_components/ArticleParts.ts
+++ b/src/app/blog/_components/ArticleParts.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { BlogPost } from '@blog/_lib/blogPost'
 

--- a/src/app/blog/_components/BadBlog/index.tsx
+++ b/src/app/blog/_components/BadBlog/index.tsx
@@ -1,6 +1,6 @@
 'use client'
-
-import React, { useState } from 'react'
+import { useContext, useState } from 'react'
+import * as React from 'react'
 
 import { Button } from '@/components/atoms/Button'
 
@@ -40,7 +40,7 @@ export function BadBlogButton() {
   ]
 
   const { badBlog, setBadBlog, badButtonFlag, setBadButtonFlag } =
-    React.useContext(BadBlogStateContext)
+    useContext(BadBlogStateContext)
 
   const handleBadBlog = () => {
     setBadButtonFlag(true)
@@ -68,7 +68,7 @@ export function BadBlogButton() {
 }
 
 export function BadBlogBlock({ children }: { children: React.ReactNode }) {
-  const { badBlog } = React.useContext(BadBlogStateContext)
+  const { badBlog } = useContext(BadBlogStateContext)
   return (
     <div className={styles.bad_blog_wrapper} data-bad-blog={badBlog}>
       {children}

--- a/src/app/blog/_components/BlogImage/ImageWithModal.tsx
+++ b/src/app/blog/_components/BlogImage/ImageWithModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import { CldImageWrapper } from '@/components/utils/CldImageWrapper'
 

--- a/src/app/blog/_components/BlogImage/index.tsx
+++ b/src/app/blog/_components/BlogImage/index.tsx
@@ -1,4 +1,5 @@
-import React, { CSSProperties } from 'react'
+import { CSSProperties } from 'react'
+import * as React from 'react'
 
 import { faCamera } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'

--- a/src/app/blog/_components/LiteArticleCard/index.tsx
+++ b/src/app/blog/_components/LiteArticleCard/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { faPencil } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import dayjs from 'dayjs'

--- a/src/app/blog/_components/OriginalMarkdownComponent.tsx
+++ b/src/app/blog/_components/OriginalMarkdownComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { ParseWithBudouX } from '@/lib/wordSplit'
 

--- a/src/app/blog/_components/PageNavigation.tsx
+++ b/src/app/blog/_components/PageNavigation.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Button } from '@/components/atoms/Button'
 
 import { BlogPost } from '@blog/_lib/blogPost'

--- a/src/app/blog/_components/PostAttributes/index.tsx
+++ b/src/app/blog/_components/PostAttributes/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { IconProp } from '@fortawesome/fontawesome-svg-core'
 import {

--- a/src/app/blog/_components/RelatedPosts.tsx
+++ b/src/app/blog/_components/RelatedPosts.tsx
@@ -1,7 +1,4 @@
 'use client'
-
-import React from 'react'
-
 import { faStar } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 

--- a/src/app/blog/_components/Tag/index.tsx
+++ b/src/app/blog/_components/Tag/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import Link from 'next/link'
 
 import styles from './index.module.scss'

--- a/src/app/blog/_components/UDFontBlock.tsx
+++ b/src/app/blog/_components/UDFontBlock.tsx
@@ -1,6 +1,6 @@
 'use client'
-
-import React, { useContext, useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
+import * as React from 'react'
 
 import { faFont, faUniversalAccess } from '@fortawesome/free-solid-svg-icons'
 import { parseCookies, setCookie } from 'nookies'

--- a/src/app/blog/_components/article-parts/Conversation/index.tsx
+++ b/src/app/blog/_components/article-parts/Conversation/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Talk } from '@/components/atoms/Talk'
 
 import { ArticleParts } from '@blog/_components/ArticleParts'

--- a/src/app/blog/_components/article-parts/HighlightedBoxes/index.tsx
+++ b/src/app/blog/_components/article-parts/HighlightedBoxes/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Alert } from '@/components/atoms/Alert'
 
 import { ArticleParts } from '@blog/_components/ArticleParts'

--- a/src/app/blog/_components/article-parts/HorizontalImages.tsx
+++ b/src/app/blog/_components/article-parts/HorizontalImages.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { ArticleParts } from '@blog/_components/ArticleParts'
 import { ImageCaption, BlogImage } from '@blog/_components/BlogImage'
 import { parseInlineMarkdown } from '@blog/_renderer/BlogMarkdown'

--- a/src/app/blog/_components/article-parts/HorizontalScroll.tsx
+++ b/src/app/blog/_components/article-parts/HorizontalScroll.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { ArticleParts } from '@blog/_components/ArticleParts'
 import { ArticleRenderer } from '@blog/_renderer/ArticleRenderer'
 

--- a/src/app/blog/_components/article-parts/LinkEmbed.tsx
+++ b/src/app/blog/_components/article-parts/LinkEmbed.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { ClientLinkCard } from '@/components/organisms/LinkCard/ClientLinkCard'
 import { ServerLinkCard } from '@/components/organisms/LinkCard/ServerLinkCard'
 

--- a/src/app/blog/_components/article-parts/ProfileCards/SwitchUI.tsx
+++ b/src/app/blog/_components/article-parts/ProfileCards/SwitchUI.tsx
@@ -1,5 +1,6 @@
 'use client'
-import React, { useState } from 'react'
+import { useState } from 'react'
+import * as React from 'react'
 
 type Props = {
   key?: React.Key

--- a/src/app/blog/_components/article-parts/ProfileCards/index.tsx
+++ b/src/app/blog/_components/article-parts/ProfileCards/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import dayjs from 'dayjs'
 import { z } from 'zod'
 

--- a/src/app/blog/_components/article-parts/ShowAll/ShowAllComponent.tsx
+++ b/src/app/blog/_components/article-parts/ShowAll/ShowAllComponent.tsx
@@ -1,5 +1,6 @@
 'use client'
-import React, { useState } from 'react'
+import { useState } from 'react'
+import * as React from 'react'
 
 type Props = {
   children: React.ReactNode

--- a/src/app/blog/_components/article-parts/ShowAll/index.tsx
+++ b/src/app/blog/_components/article-parts/ShowAll/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { ShowAllComponent } from '@blog/_components/article-parts/ShowAll/ShowAllComponent'
 import { ArticleParts } from '@blog/_components/ArticleParts'
 import { ArticleRenderer } from '@blog/_renderer/ArticleRenderer'

--- a/src/app/blog/_components/article-parts/Twitter/index.tsx
+++ b/src/app/blog/_components/article-parts/Twitter/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { Tweet } from '@/components/utils/TweetWrapper'
 

--- a/src/app/blog/_components/article-parts/TwitterArchive/index.tsx
+++ b/src/app/blog/_components/article-parts/TwitterArchive/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { z } from 'zod'
 

--- a/src/app/blog/_components/article-parts/WalkingResultBox/index.tsx
+++ b/src/app/blog/_components/article-parts/WalkingResultBox/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { ArticleParts } from '@blog/_components/ArticleParts'
 import { parseColonSeparatedList } from '@blog/_lib/rawTextParser'
 

--- a/src/app/blog/_components/article-parts/YouTube/InnerYouTube.tsx
+++ b/src/app/blog/_components/article-parts/YouTube/InnerYouTube.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import React from 'react'
+import { memo } from 'react'
 
 import ReactPlayer from 'react-player/youtube'
 import YouTube from 'react-youtube'
 
-export const InnerYouTube = React.memo(function InnerYouTube({
+export const InnerYouTube = memo(function InnerYouTube({
   content,
 }: {
   content: string
@@ -24,7 +24,7 @@ export const InnerYouTube = React.memo(function InnerYouTube({
   )
 })
 
-export const InnerAutoYouTube = React.memo(function InnerAutoYouTube({
+export const InnerAutoYouTube = memo(function InnerAutoYouTube({
   content,
 }: {
   content: string

--- a/src/app/blog/_renderer/ArticleRenderer.tsx
+++ b/src/app/blog/_renderer/ArticleRenderer.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { memo } from 'react'
 
 import { MDXRemote, MDXRemoteProps } from 'next-mdx-remote/rsc'
 
@@ -21,7 +21,7 @@ export type ArticleRendererProps =
       entry?: BlogPost
     }
 
-export const ArticleRenderer = React.memo(function ArticleRenderer(
+export const ArticleRenderer = memo(function ArticleRenderer(
   props: ArticleRendererProps,
 ) {
   let options: MarkdownOptions

--- a/src/app/blog/_renderer/BlogMarkdown.tsx
+++ b/src/app/blog/_renderer/BlogMarkdown.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties } from 'react'
+import { memo, CSSProperties } from 'react'
 
 import { MDXRemote } from 'next-mdx-remote/rsc'
 
@@ -22,9 +22,7 @@ type Props = {
   className?: string
 }
 
-export const BlogMarkdown = React.memo(function InnerBlogMarkdown(
-  props: Props,
-) {
+export const BlogMarkdown = memo(function InnerBlogMarkdown(props: Props) {
   const { entry, style, className } = props
   const markdown = entry.content
 

--- a/src/app/blog/_renderer/DevBlogMarkdown/DevBlogMarkdown.tsx
+++ b/src/app/blog/_renderer/DevBlogMarkdown/DevBlogMarkdown.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useDeferredValue, useEffect, useState } from 'react'
+import { useRef, useDeferredValue, useEffect, useState } from 'react'
 
 import { io } from 'socket.io-client'
 
@@ -49,7 +49,7 @@ export function DevBlogMarkdown(props: DevBlogMarkdownProps) {
   }, [props.page, props.slug])
 
   // scroll
-  const documentHeight = React.useRef<number>(-1)
+  const documentHeight = useRef<number>(-1)
 
   useEffect(() => {
     const resizeObserver = new ResizeObserver(() => {

--- a/src/app/blog/_renderer/DevBlogMarkdown/ImageDragAndDrop.tsx
+++ b/src/app/blog/_renderer/DevBlogMarkdown/ImageDragAndDrop.tsx
@@ -1,5 +1,6 @@
 'use client'
-import React, { useCallback, useState } from 'react'
+import { useCallback, useState } from 'react'
+import * as React from 'react'
 
 import { CodeBlock } from '@/components/molecules/CodeBlock'
 

--- a/src/app/blog/_renderer/DevBlogMarkdown/useUploadFunction.tsx
+++ b/src/app/blog/_renderer/DevBlogMarkdown/useUploadFunction.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import { useCallback } from 'react'
 
 import toast from 'react-hot-toast'
 

--- a/src/app/blog/_renderer/rendererProperties.tsx
+++ b/src/app/blog/_renderer/rendererProperties.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { faPaperclip } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'

--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { Metadata } from 'next'
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { Fragment } from 'react'
 
 import { Metadata } from 'next'
 
@@ -60,7 +60,7 @@ export default async function Index() {
         {getTypedEntries(articlesGroupedByYear)
           .reverse()
           .map(([year, articles]) => (
-            <React.Fragment key={year as string}>
+            <Fragment key={year as string}>
               <div className={styles.hrule_block}>
                 <FontAwesomeIcon icon={faStar} /> {year as string} 年{' '}
                 <FontAwesomeIcon icon={faStar} />
@@ -73,7 +73,7 @@ export default async function Index() {
                   <LiteArticleCard entry={entry} key={entry.slug} />
                 ))}
               </div>
-            </React.Fragment>
+            </Fragment>
           ))}
       </MainWrapper>
     </>

--- a/src/app/blog/preview/[...slug]/page.tsx
+++ b/src/app/blog/preview/[...slug]/page.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Metadata } from 'next'
 
 import { MainWrapper } from '@/components/atoms/MainWrapper'

--- a/src/app/blog/tags/[tag]/page.tsx
+++ b/src/app/blog/tags/[tag]/page.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Button } from '@/components/atoms/Button'
 import { MainWrapper } from '@/components/atoms/MainWrapper'
 import { Title } from '@/components/organisms/Title'

--- a/src/app/environment/GadgetIntro.tsx
+++ b/src/app/environment/GadgetIntro.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import Image from 'next/legacy/image'
 

--- a/src/app/environment/page.tsx
+++ b/src/app/environment/page.tsx
@@ -1,7 +1,7 @@
 import fs from 'fs/promises'
 import path from 'path'
 
-import React from 'react'
+import { Fragment } from 'react'
 
 import { Metadata } from 'next'
 
@@ -51,14 +51,14 @@ function Itemize(props: {
           return <li key={index}>{child}</li>
         }
         return (
-          <React.Fragment key={index}>
+          <Fragment key={index}>
             {Object.entries(child).map(([key, value]) => (
-              <React.Fragment key={key}>
+              <Fragment key={key}>
                 <li>{key}</li>
                 <Itemize>{value}</Itemize>
-              </React.Fragment>
+              </Fragment>
             ))}
-          </React.Fragment>
+          </Fragment>
         )
       })}
     </ul>

--- a/src/app/fuzzy/layout.tsx
+++ b/src/app/fuzzy/layout.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { Metadata } from 'next'
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
-import React, { Suspense } from 'react'
+import { Suspense } from 'react'
+import * as React from 'react'
 
 import '@/styles/globals.scss'
 import 'react-loading-skeleton/dist/skeleton.css'

--- a/src/app/legal/layout.tsx
+++ b/src/app/legal/layout.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { MainWrapper } from '@/components/atoms/MainWrapper'
 

--- a/src/app/links/MutualLinkBlock.tsx
+++ b/src/app/links/MutualLinkBlock.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import styles from '@/app/(home)/page.module.scss'
 

--- a/src/app/links/page.tsx
+++ b/src/app/links/page.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Metadata } from 'next'
 
 import styles from '@/app/(home)/page.module.scss'

--- a/src/app/music/layout.tsx
+++ b/src/app/music/layout.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { Metadata } from 'next'
 

--- a/src/app/tweets/PageNavigation/index.tsx
+++ b/src/app/tweets/PageNavigation/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React from 'react'
+import { Fragment } from 'react'
 
 import { useSearchParams } from 'next/navigation'
 
@@ -76,9 +76,9 @@ export function PageNavigation(props: {
       </span>
       <div className={styles.button_wrapper}>
         {buttons.map(pageNo => (
-          <React.Fragment key={`navigation-${pageNo}-${props.key}`}>
+          <Fragment key={`navigation-${pageNo}-${props.key}`}>
             <Button pageNo={pageNo} current={pageNo === props.currentPage} />
-          </React.Fragment>
+          </Fragment>
         ))}
       </div>
     </div>

--- a/src/app/tweets/TweetArea/index.tsx
+++ b/src/app/tweets/TweetArea/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { PageNavigation } from '@/app/tweets/PageNavigation'
 import { DateCard, TweetCard } from '@/app/tweets/TweetCard'

--- a/src/app/tweets/TweetCard/index.tsx
+++ b/src/app/tweets/TweetCard/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { faStar, faRetweet, faHeart } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'

--- a/src/app/tweets/page.tsx
+++ b/src/app/tweets/page.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Metadata } from 'next'
 
 import dayjs from 'dayjs'

--- a/src/app/works/page.tsx
+++ b/src/app/works/page.tsx
@@ -1,7 +1,5 @@
 import path from 'path'
 
-import React from 'react'
-
 import { Metadata } from 'next'
 
 import Image from 'next/legacy/image'
@@ -16,11 +14,11 @@ import { readMarkdowns } from '@/lib/mdLoader'
 
 import styles from './style.module.scss'
 
-type KeywordsType = {
+type KeywordsProps = {
   keywords: string[]
 }
 
-const Keywords: React.FC<KeywordsType> = ({ keywords }) => {
+function Keywords({ keywords }: KeywordsProps) {
   return (
     <p className={styles.keywords}>
       <span className={styles.keyword_title}>TECHNOLOGIES</span>

--- a/src/components/atoms/Alert/index.tsx
+++ b/src/components/atoms/Alert/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import {
   faCircleInfo,

--- a/src/components/atoms/AnglePicker/index.tsx
+++ b/src/components/atoms/AnglePicker/index.tsx
@@ -1,5 +1,6 @@
 'use client'
-import React from 'react'
+import * as React from 'react'
+import { useCallback, useImperativeHandle, useRef, useState } from 'react'
 
 import { DivWithDragEvent } from '@/components/atoms/DivWithDragEvent'
 
@@ -28,12 +29,12 @@ export const AnglePicker = React.forwardRef<AnglePickerHandle, Props>(
       initialDegree = 0,
       ...rest
     } = props
-    const [degree, setDegree] = React.useState(initialDegree)
+    const [degree, setDegree] = useState(initialDegree)
 
-    const innerRef = React.useRef<HTMLDivElement>(null)
+    const innerRef = useRef<HTMLDivElement>(null)
 
     // ref.current.setDegree で手動での角度変更をできるようにする
-    React.useImperativeHandle(ref, () => ({
+    useImperativeHandle(ref, () => ({
       setDegree: manualDegree => {
         setDegree(prev => {
           const newDegree =
@@ -46,7 +47,7 @@ export const AnglePicker = React.forwardRef<AnglePickerHandle, Props>(
       },
     }))
 
-    const setAngleFromMouseEvent = React.useCallback(
+    const setAngleFromMouseEvent = useCallback(
       (e: MouseEvent) => {
         const rect = innerRef.current?.getBoundingClientRect()
         if (!e || !rect) {

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import classNames from 'classnames'
 import Link from 'next/link'

--- a/src/components/atoms/ButtonWithTooltip/index.tsx
+++ b/src/components/atoms/ButtonWithTooltip/index.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import * as React from 'react'
+import { useCallback, useId, useState } from 'react'
 
 import { Tooltip } from 'react-tooltip'
 
@@ -17,11 +18,11 @@ export function ButtonWithTooltip(props: ButtonWithTooltipProps) {
     ...rest
   } = props
 
-  const [isClicked, setIsClicked] = React.useState(false)
-  const [tooltipTimeoutId, setTooltipTimeoutId] = React.useState<number>(0)
-  const tooltipId = React.useId()
+  const [isClicked, setIsClicked] = useState(false)
+  const [tooltipTimeoutId, setTooltipTimeoutId] = useState<number>(0)
+  const tooltipId = useId()
 
-  const clickHandler = React.useCallback(
+  const clickHandler = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
       onClick?.(e)
       if (tooltipTimeoutId) {
@@ -36,7 +37,7 @@ export function ButtonWithTooltip(props: ButtonWithTooltipProps) {
     [onClick, tooltipTimeoutId],
   )
 
-  const mouseLeaveHandler = React.useCallback(() => {
+  const mouseLeaveHandler = useCallback(() => {
     if (tooltipTimeoutId) {
       clearTimeout(tooltipTimeoutId)
     }

--- a/src/components/atoms/CircleButton/index.stories.tsx
+++ b/src/components/atoms/CircleButton/index.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { faTwitter, faXTwitter } from '@fortawesome/free-brands-svg-icons'
 import { faAngleDoubleUp } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'

--- a/src/components/atoms/CircleButton/index.tsx
+++ b/src/components/atoms/CircleButton/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import styles from './index.module.scss'
 

--- a/src/components/atoms/Details/index.tsx
+++ b/src/components/atoms/Details/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import styles from './index.module.scss'
 

--- a/src/components/atoms/DivWithDragEvent.tsx
+++ b/src/components/atoms/DivWithDragEvent.tsx
@@ -1,5 +1,6 @@
 // 要素内でドラッグを開始したとき、要素外でもドラッグを継続するためのコンポーネント
-import React from 'react'
+import * as React from 'react'
+import { useCallback, useState, useEffect } from 'react'
 
 type Props = React.ComponentPropsWithRef<'div'> & {
   onDragging: (e: MouseEvent) => void
@@ -9,8 +10,8 @@ export const DivWithDragEvent = React.forwardRef<HTMLDivElement, Props>(
   function DivWithDragEvent(props, ref) {
     const { onDragging, onMouseDown, onClick, ...rest } = props
 
-    const [isDragging, setIsDragging] = React.useState(false)
-    const handleDrag = React.useCallback(
+    const [isDragging, setIsDragging] = useState(false)
+    const handleDrag = useCallback(
       (e: MouseEvent) => {
         if (!isDragging) return // div 外のドラッグにも反応してしまうため、これより上には処理を書かない
         e.preventDefault()
@@ -20,13 +21,13 @@ export const DivWithDragEvent = React.forwardRef<HTMLDivElement, Props>(
       [isDragging, onDragging],
     )
 
-    const mouseUpHandler = React.useCallback(() => {
+    const mouseUpHandler = useCallback(() => {
       document.body.style.touchAction = ''
       setIsDragging(false)
     }, [setIsDragging])
 
     // 要素外でもドラッグと mouse up を検知するため document にイベントを登録する
-    React.useEffect(() => {
+    useEffect(() => {
       document.addEventListener('pointerup', mouseUpHandler)
       document.addEventListener('pointermove', handleDrag)
       return () => {

--- a/src/components/atoms/ErrorFallback/index.tsx
+++ b/src/components/atoms/ErrorFallback/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import styles from './index.module.scss'
 

--- a/src/components/atoms/FoggedDiv/index.stories.tsx
+++ b/src/components/atoms/FoggedDiv/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { Fragment } from 'react'
 
 import { LOREM_IPSUM } from '@/lib/constants'
 
@@ -24,7 +24,7 @@ export const Primary: Story = {
     height: 100,
     fogHeight: 20,
     children: Array.from(Array(20)).map((e, i) => (
-      <React.Fragment key={i}>{LOREM_IPSUM}</React.Fragment>
+      <Fragment key={i}>{LOREM_IPSUM}</Fragment>
     )),
   },
 }

--- a/src/components/atoms/FoggedDiv/index.tsx
+++ b/src/components/atoms/FoggedDiv/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React from 'react'
+import * as React from 'react'
 
 import styles from './index.module.scss'
 

--- a/src/components/atoms/H2/index.tsx
+++ b/src/components/atoms/H2/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import styles from './index.module.scss'
 

--- a/src/components/atoms/HoverScrollBox/index.tsx
+++ b/src/components/atoms/HoverScrollBox/index.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import React from 'react'
-
 type Props = React.ComponentPropsWithoutRef<'div'>
+
+import * as React from 'react'
+import { useRef } from 'react'
 
 import styles from './index.module.scss'
 import { useHoverScrollBoxEvent } from './useHoverScrollBoxEvent'
@@ -11,7 +12,7 @@ import { useScrollPosition } from './useScrollPosition'
 export function HoverScrollBox(props: Props) {
   const { className = '', children, ...rest } = props
 
-  const scrollAreaRef = React.useRef<HTMLDivElement>(null)
+  const scrollAreaRef = useRef<HTMLDivElement>(null)
   const { handleMouseEnter, handleMouseLeave } =
     useHoverScrollBoxEvent(scrollAreaRef)
   const { scrollPosition, handleScroll } = useScrollPosition()

--- a/src/components/atoms/HoverScrollBox/useHoverScrollBoxEvent.ts
+++ b/src/components/atoms/HoverScrollBox/useHoverScrollBoxEvent.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 export function useHoverScrollBoxEvent(
   scrollAreaRef: React.RefObject<HTMLElement>,

--- a/src/components/atoms/HoverScrollBox/useScrollPosition.ts
+++ b/src/components/atoms/HoverScrollBox/useScrollPosition.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { useThrottledCallback } from '@react-hookz/web'
 

--- a/src/components/atoms/MainWrapper/index.tsx
+++ b/src/components/atoms/MainWrapper/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import styles from './index.module.scss'
 

--- a/src/components/atoms/OpenInNewTab.tsx
+++ b/src/components/atoms/OpenInNewTab.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 export type OpenInNewTabProps = Omit<
   React.ComponentPropsWithoutRef<'a'>,

--- a/src/components/atoms/PlainBlock/index.tsx
+++ b/src/components/atoms/PlainBlock/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import styles from './index.module.scss'
 

--- a/src/components/atoms/Talk/index.tsx
+++ b/src/components/atoms/Talk/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import styles from './index.module.scss'
 

--- a/src/components/atoms/WaveText/index.tsx
+++ b/src/components/atoms/WaveText/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import styles from './index.module.scss'
 

--- a/src/components/atoms/twitter/TweetTextarea/index.tsx
+++ b/src/components/atoms/twitter/TweetTextarea/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import styles from './index.module.scss'
 

--- a/src/components/atoms/twitter/TwitterIcon/index.tsx
+++ b/src/components/atoms/twitter/TwitterIcon/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import styles from './index.module.scss'
 import { iconPreset } from './preset'

--- a/src/components/atoms/twitter/TwitterIcon/preset.ts
+++ b/src/components/atoms/twitter/TwitterIcon/preset.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 const trpfrogUrl =
   'https://res.cloudinary.com/trpfrog/image/upload/w_50,q_auto/icons_gallery/28'

--- a/src/components/atoms/twitter/TwitterImage/index.tsx
+++ b/src/components/atoms/twitter/TwitterImage/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import styles from './index.module.scss'
 
 export type TwitterImageData = {

--- a/src/components/molecules/Block/index.tsx
+++ b/src/components/molecules/Block/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { H2Icon, H2 } from '@/components/atoms/H2'
 import { PlainBlock } from '@/components/atoms/PlainBlock'

--- a/src/components/molecules/BlockLink/index.tsx
+++ b/src/components/molecules/BlockLink/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import Link, { LinkProps } from 'next/link'
 

--- a/src/components/molecules/CodeBlock/customPrismTheme.ts
+++ b/src/components/molecules/CodeBlock/customPrismTheme.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 export const customPrismTheme: Record<string, React.CSSProperties> = {
   'code[class*="language-"]': {

--- a/src/components/molecules/CodeBlock/index.tsx
+++ b/src/components/molecules/CodeBlock/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React from 'react'
+import * as React from 'react'
 
 import { faClone } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'

--- a/src/components/molecules/CodeBlock/useLineHighlight.ts
+++ b/src/components/molecules/CodeBlock/useLineHighlight.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import { useRef, useEffect } from 'react'
 
 import styles from './index.module.scss'
 
@@ -7,10 +7,10 @@ export function useLineHighlight(lines: {
   warningLines?: number[]
   infoLines?: number[]
 }) {
-  const ref = React.useRef<HTMLDivElement>(null)
+  const ref = useRef<HTMLDivElement>(null)
 
   const { errorLines, warningLines, infoLines } = lines
-  React.useEffect(() => {
+  useEffect(() => {
     if (ref.current) {
       const lines = ref.current?.children
       if (lines) {

--- a/src/components/molecules/FullHeight/index.tsx
+++ b/src/components/molecules/FullHeight/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import styles from './index.module.scss'
 

--- a/src/components/molecules/Hamburger/index.tsx
+++ b/src/components/molecules/Hamburger/index.tsx
@@ -1,7 +1,4 @@
 'use client'
-
-import React from 'react'
-
 import {
   useMobileMenuState,
   useToggleMenuCallback,

--- a/src/components/molecules/ShowAll/index.stories.tsx
+++ b/src/components/molecules/ShowAll/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { Fragment } from 'react'
 
 import { LOREM_IPSUM } from '@/lib/constants'
 
@@ -24,7 +24,7 @@ export const Primary: Story = {
     showAllByDefault: false,
     height: 100,
     children: Array.from(Array(20)).map((e, i) => (
-      <React.Fragment key={i}>{LOREM_IPSUM}</React.Fragment>
+      <Fragment key={i}>{LOREM_IPSUM}</Fragment>
     )),
   },
 }

--- a/src/components/molecules/ShowAll/index.test.tsx
+++ b/src/components/molecules/ShowAll/index.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, screen } from '@testing-library/react'
 import { act } from 'react-dom/test-utils'
 

--- a/src/components/molecules/ShowAll/index.tsx
+++ b/src/components/molecules/ShowAll/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React from 'react'
+import { useState, useRef, useEffect } from 'react'
 
 import { FoggedDiv, FoggedDivProps } from '@/components/atoms/FoggedDiv'
 import { usePixelValueFromCSSLength } from '@/components/molecules/ShowAll/usePixelValueFromCSSLength'
@@ -20,14 +20,14 @@ export function ShowAll(props: ShowAllProps) {
     children,
     ...rest
   } = props
-  const [isShowAll, setIsShowAll] = React.useState(showAllByDefault ?? false)
-  const [needsFog, setNeedsFog] = React.useState(true) // コンテンツが少なすぎるときは Fog を表示しない
+  const [isShowAll, setIsShowAll] = useState(showAllByDefault ?? false)
+  const [needsFog, setNeedsFog] = useState(true) // コンテンツが少なすぎるときは Fog を表示しない
 
-  const ref = React.useRef<HTMLDivElement>(null)
+  const ref = useRef<HTMLDivElement>(null)
   const maxHeightPx = usePixelValueFromCSSLength(ref, height)
 
   // コンテンツの高さから、Fog を表示するかどうかを決める
-  React.useEffect(() => {
+  useEffect(() => {
     const innerHeight = ref.current?.clientHeight
     if (innerHeight && maxHeightPx) {
       setNeedsFog(innerHeight > maxHeightPx)

--- a/src/components/molecules/ShowAll/usePixelValueFromCSSLength.ts
+++ b/src/components/molecules/ShowAll/usePixelValueFromCSSLength.ts
@@ -1,5 +1,5 @@
 // return the pixel value of the CSS length (e.g. '1em' => 16)
-import React from 'react'
+import * as React from 'react'
 
 import { useRerender } from '@react-hookz/web'
 

--- a/src/components/molecules/TwitterHeader/index.tsx
+++ b/src/components/molecules/TwitterHeader/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { faDove } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'

--- a/src/components/organisms/BackToTop/index.tsx
+++ b/src/components/organisms/BackToTop/index.tsx
@@ -1,7 +1,4 @@
 'use client'
-
-import React from 'react'
-
 import { faAngleDoubleUp } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 

--- a/src/components/organisms/Header/index.tsx
+++ b/src/components/organisms/Header/index.tsx
@@ -1,6 +1,6 @@
 'use client'
-
-import React, { useEffect } from 'react'
+import { useEffect } from 'react'
+import * as React from 'react'
 
 import { atom, useAtomValue, useSetAtom } from 'jotai'
 import Link from 'next/link'

--- a/src/components/organisms/LinkCard/ClientLinkCard.tsx
+++ b/src/components/organisms/LinkCard/ClientLinkCard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React from 'react'
+import * as React from 'react'
 
 import useSWR from 'swr'
 

--- a/src/components/organisms/LinkCard/LinkCard.tsx
+++ b/src/components/organisms/LinkCard/LinkCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { faEarthAsia } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'

--- a/src/components/organisms/LinkCard/ServerLinkCard.tsx
+++ b/src/components/organisms/LinkCard/ServerLinkCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { ClientLinkCard } from '@/components/organisms/LinkCard/ClientLinkCard'
 import { fetchOGP } from '@/components/organisms/LinkCard/fetchOGP'

--- a/src/components/organisms/LinkCard/SkeletonLinkCard.tsx
+++ b/src/components/organisms/LinkCard/SkeletonLinkCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import classNames from 'classnames'
 import Skeleton from 'react-loading-skeleton'

--- a/src/components/organisms/MobileMenu/Settings.tsx
+++ b/src/components/organisms/MobileMenu/Settings.tsx
@@ -1,6 +1,4 @@
 'use client'
-import React from 'react'
-
 import { useShouldFollowHeaderAtom } from '@/states/shouldFollowHeaderAtom'
 import { useShouldHideHeaderAtom } from '@/states/shouldHideHeaderAtom'
 import { useShowSiteCommentsAtom } from '@/states/showSiteCommentsAtom'

--- a/src/components/organisms/MobileMenu/index.tsx
+++ b/src/components/organisms/MobileMenu/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React from 'react'
+import { useCallback, memo } from 'react'
 
 import { atom, useAtom } from 'jotai'
 import Link from 'next/link'
@@ -23,13 +23,13 @@ export function useToggleMenuCallback() {
   const [isOpened, setHamburgerState] = useMobileMenuState()
   const setAlwaysShownHeader = useSetAlwaysShownHeader()
 
-  return React.useCallback(() => {
+  return useCallback(() => {
     setHamburgerState(!isOpened)
     setAlwaysShownHeader(!isOpened)
   }, [isOpened, setAlwaysShownHeader, setHamburgerState])
 }
 
-export const MobileMenu = React.memo(function MobileMenu() {
+export const MobileMenu = memo(function MobileMenu() {
   const doNothing = () => {}
   const toggleMenu = useToggleMenuCallback()
 

--- a/src/components/organisms/Navigation/index.tsx
+++ b/src/components/organisms/Navigation/index.tsx
@@ -1,7 +1,4 @@
 'use client'
-
-import React from 'react'
-
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 

--- a/src/components/organisms/Title/index.tsx
+++ b/src/components/organisms/Title/index.tsx
@@ -1,4 +1,5 @@
-import React, { CSSProperties } from 'react'
+import { CSSProperties } from 'react'
+import * as React from 'react'
 
 import { Block } from '@/components/molecules/Block'
 

--- a/src/components/organisms/TwitterArchived/index.tsx
+++ b/src/components/organisms/TwitterArchived/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import { TweetTextarea } from '@/components/atoms/twitter/TweetTextarea'
 import {

--- a/src/components/utils/CldImageWrapper.tsx
+++ b/src/components/utils/CldImageWrapper.tsx
@@ -1,7 +1,4 @@
 'use client'
-
-import React from 'react'
-
 import Image, { ImageProps } from 'next/image'
 
 import { cloudinaryLoader } from '@blog/_lib/cloudinaryUtils'

--- a/src/components/utils/JotaiProvider.tsx
+++ b/src/components/utils/JotaiProvider.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React from 'react'
+import * as React from 'react'
 
 import { Provider } from 'jotai'
 

--- a/src/components/utils/MathJaxWrapper.tsx
+++ b/src/components/utils/MathJaxWrapper.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import React from 'react'
+import * as React from 'react'
 
 import {
   MathJax,

--- a/src/hooks/useScrollPositionKeeper.ts
+++ b/src/hooks/useScrollPositionKeeper.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 export function useScrollPositionKeeper(ref?: React.RefObject<HTMLElement>) {
   const scrollPosition = React.useRef(0)

--- a/src/lib/wordSplit/index.tsx
+++ b/src/lib/wordSplit/index.tsx
@@ -1,15 +1,13 @@
 'use client'
 
-import React from 'react'
+import { createContext, useContext } from 'react'
 
 import dynamic from 'next/dynamic'
 
 import type { ParseWithBudouXProps } from '@/lib/wordSplit/wordSplit'
 
 // Hack to pass props to loading() of dynamic import
-const LoadingPropsContext = React.createContext<ParseWithBudouXProps | null>(
-  null,
-)
+const LoadingPropsContext = createContext<ParseWithBudouXProps | null>(null)
 
 const SSRSafeParseWithBudouX = dynamic(
   () => import('./wordSplit').then(m => m._ParseWithBudouX),
@@ -17,7 +15,7 @@ const SSRSafeParseWithBudouX = dynamic(
     ssr: false,
     loading: () => {
       function InnerLoadingParseWithBudouX() {
-        const props = React.useContext(LoadingPropsContext)
+        const props = useContext(LoadingPropsContext)
         return props ? <span>{props.str}</span> : <></>
       }
       return <InnerLoadingParseWithBudouX />


### PR DESCRIPTION
React 17 より JSX を使う場合に `import React from 'react'` しなくて良くなっているそうなので、不要な import 文を削除した。移行には以下のように codemod を利用し、自動変換できなかった部分は手動で調整した。(TS の satisfies が含まれているファイル？が自動変換に対応していないようだった)

```
npx react-codemod update-react-imports ./src
```

source: https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
