### PR TITLE
Fix rotate left button in iconMaker

### DIFF
--- a/apps/trpfrog.net/src/app/icon-maker/iconMakerHooks.ts
+++ b/apps/trpfrog.net/src/app/icon-maker/iconMakerHooks.ts
@@ -47,7 +47,7 @@ export function useIconMakerController(state: MutableRefObject<IconCanvas>) {
         },
         {
           className: styles.rotate_left_btn,
-          onClick: () => state.current?.rotateImage(5),
+          onClick: () => state.current?.rotateImage(-5),
           text: '←R',
         },
         {


### PR DESCRIPTION
This pull request includes a small but important change to the `useIconMakerController` function in the `iconMakerHooks.ts` file. The change corrects the rotation direction of an image when the rotate left button is clicked.

* [`apps/trpfrog.net/src/app/icon-maker/iconMakerHooks.ts`](diffhunk://#diff-aefdb84de20c4400f2ad8526377726e792b7c801fc6fd283da670eec6cf3c47fL50-R50): Modified the `onClick` handler for the rotate left button to rotate the image by -5 degrees instead of 5 degrees.