### PR TITLE
iOS 18.2 の Safari でサイトデザインが崩れる問題を修正

### DIFF
--- a/apps/trpfrog.net/src/styles/variables.css
+++ b/apps/trpfrog.net/src/styles/variables.css
@@ -2,13 +2,17 @@
   --h3-marker-color: #90e200;
   --body-background: rgb(192, 225, 121);
   --base-font-color: #151515;
+}
 
-  @media screen and (prefers-color-scheme: dark) {
+@media screen and (prefers-color-scheme: dark) {
+  :root {
     --h3-marker-color: #4e8018;
     --body-background: #3d4d22;
     --base-font-color: #e5e5e5;
   }
+}
 
+:root {
   --trpfrog-animation-start-degree: 0rad;
   --anim-height: min(100vw, 400px);
   --trpfrog-icon-size: min(400px, 90vw);
@@ -17,67 +21,85 @@
     Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
 
   --footer-color: #163600;
+}
 
-  /*--------------- from block.scss --------------*/
-
+/*--------------- from block.scss --------------*/
+:root {
   --window-padding-top-bottom: 40px;
   --window-padding-left-right: 40px;
   --window-bottom-color: #9cc535;
   --window-border-radius: 15px;
+}
 
-  @media screen and (max-width: 800px) {
+@media screen and (max-width: 800px) {
+  :root {
     --window-padding-top-bottom: 18px;
     --window-padding-left-right: 12px;
     --window-border-radius: 10px;
   }
+}
 
-  @media screen and (prefers-color-scheme: dark) {
+@media screen and (prefers-color-scheme: dark) {
+  :root {
     --window-bottom-color: #35420e;
   }
+}
 
-  /*--------------- from grid.scss ---------------*/
-
+/*--------------- from grid.scss ---------------*/
+:root {
   --header-height: 4rem;
   --navigation-height: 3em;
   --footer-height: 3em;
   --main-margin: 2em;
   --window-bkg-color: white;
+}
 
-  @media screen and (max-width: 800px) {
+@media screen and (max-width: 800px) {
+  :root {
     --header-height: 3rem;
     --navigation-height: 0px;
     --footer-height: 3em;
     --main-margin: 8px;
   }
+}
 
-  @media screen and (prefers-color-scheme: dark) {
+@media screen and (prefers-color-scheme: dark) {
+  :root {
     --window-bkg-color: #202020;
   }
+}
 
-  /*-------------- from colors.scss --------------*/
-
+/*-------------- from colors.scss --------------*/
+:root {
   --link-button-color: #77bd36;
   --link-button-color-bottom: #558d21;
   --link-button-color-highlighted: #90e200;
   --link-button-font-color: white;
+}
 
-  @media screen and (prefers-color-scheme: dark) {
+@media screen and (prefers-color-scheme: dark) {
+  :root {
     --link-button-color: #558d21;
     --link-button-color-bottom: #406919;
     --link-button-color-highlighted: #7fc900;
   }
+}
 
-  /*-------------- from header.scss --------------*/
-
+/*-------------- from header.scss --------------*/
+:root {
   --header-color: #66a928;
   --header-filter: 0 0.2em 0 #5a9623;
   --header-icon-size: 70px;
+}
 
-  @media screen and (max-width: 800px) {
+@media screen and (max-width: 800px) {
+  :root {
     --header-icon-size: 58px;
   }
+}
 
-  @media screen and (prefers-color-scheme: dark) {
+@media screen and (prefers-color-scheme: dark) {
+  :root {
     --header-color: #4f831f;
     --header-filter: 0 0.2em 0 rgb(49, 80, 15);
   }


### PR DESCRIPTION
iOS 18.2 の Safari で `:root` 内にメディアクエリを書くとうまく動かない現象があります。

```css
:root {
  --my-variable: 16px;
  @media screen and (max-width: 800px) {
    --my-variable: 8px;
  }
}
```

CSS 変数の宣言部分を次のように修正するとうまく動くのでそんな感じで書き換えました。

```css
:root {
  --my-variable: 16px;
}

@media screen and (max-width: 800px) {
  :root {
    --my-variable: 8px;
  }
}
```
